### PR TITLE
Add Husky script for GraphQL Schema Validation

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,3 @@
 #!/usr/bin/env sh
-. "$(dirname "$0")/_/husky.sh"
 
-# Run the schema validation script
-./scripts/validate-schema.sh
+sh scripts/validate-graphql-schema.sh

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,29 @@
+#!/usr/bin/env sh
+
+# Check for changes in GraphQL schema files
+SCHEMA_CHANGES=$(git diff --cached --name-only -- '*.graphql' '*.gql')
+
+if [ -n "$SCHEMA_CHANGES" ]; then
+  echo "GraphQL schema changes detected. Checking if generated code is up-to-date..."
+
+  # Stash any unstaged changes to avoid interference
+  git stash push --keep-index --quiet
+
+  # Run the codegen tool to see if the generated code would change
+  npx graphql-codegen --check
+
+  # Capture the output of the dry-run
+  CODE_GEN_OUTPUT=$(npx graphql-codegen --check 2>&1)
+
+  # Unstash the changes
+  git stash pop --quiet
+
+  # Check if the dry-run output indicates changes
+  if echo "$CODE_GEN_OUTPUT" | grep -q "Changes detected"; then
+    echo "Error: Generated code is out of sync with the schema."
+    echo "Please run 'npx graphql-codegen' and commit the changes."
+    exit 1
+  else
+    echo "Generated code is up-to-date. Proceeding with the commit."
+  fi
+fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,29 +1,5 @@
 #!/usr/bin/env sh
+. "$(dirname "$0")/_/husky.sh"
 
-# Check for changes in GraphQL schema files
-SCHEMA_CHANGES=$(git diff --cached --name-only -- '*.graphql' '*.gql')
-
-if [ -n "$SCHEMA_CHANGES" ]; then
-  echo "GraphQL schema changes detected. Checking if generated code is up-to-date..."
-
-  # Stash any unstaged changes to avoid interference
-  git stash push --keep-index --quiet
-
-  # Run the codegen tool to see if the generated code would change
-  npx graphql-codegen --check
-
-  # Capture the output of the dry-run
-  CODE_GEN_OUTPUT=$(npx graphql-codegen --check 2>&1)
-
-  # Unstash the changes
-  git stash pop --quiet
-
-  # Check if the dry-run output indicates changes
-  if echo "$CODE_GEN_OUTPUT" | grep -q "Changes detected"; then
-    echo "Error: Generated code is out of sync with the schema."
-    echo "Please run 'npx graphql-codegen' and commit the changes."
-    exit 1
-  else
-    echo "Generated code is up-to-date. Proceeding with the commit."
-  fi
-fi
+# Run the schema validation script
+./scripts/validate-schema.sh

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "aws-cdk": "2.1003.0",
         "eslint": "^9.22.0",
         "graphql": "^16.10.0",
+        "husky": "^9.1.7",
         "jest": "^29.7.0",
         "prettier": "^3.5.3",
         "ts-jest": "^29.2.5",
@@ -8169,6 +8170,21 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/iconv-lite": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "test": "jest",
     "cdk": "cdk",
     "format": "prettier --write .",
-    "lint": "eslint . --ext .ts"
+    "lint": "eslint . --ext .ts",
+    "prepare": "husky"
   },
   "devDependencies": {
     "@graphql-codegen/cli": "^5.0.5",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "test": "jest",
     "cdk": "cdk",
     "format": "prettier --write .",
-    "lint": "eslint . --ext .ts"
+    "lint": "eslint . --ext .ts",
+    "prepare": "husky"
   },
   "devDependencies": {
     "@graphql-codegen/cli": "^5.0.5",
@@ -25,6 +26,7 @@
     "aws-cdk": "2.1003.0",
     "eslint": "^9.22.0",
     "graphql": "^16.10.0",
+    "husky": "^9.1.7",
     "jest": "^29.7.0",
     "prettier": "^3.5.3",
     "ts-jest": "^29.2.5",

--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
     "test": "jest",
     "cdk": "cdk",
     "format": "prettier --write .",
-    "lint": "eslint . --ext .ts",
-    "prepare": "husky install"
+    "lint": "eslint . --ext .ts"
   },
   "devDependencies": {
     "@graphql-codegen/cli": "^5.0.5",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "cdk": "cdk",
     "format": "prettier --write .",
     "lint": "eslint . --ext .ts",
-    "prepare": "husky"
+    "prepare": "husky install"
   },
   "devDependencies": {
     "@graphql-codegen/cli": "^5.0.5",

--- a/scripts/validate-graphql-schema.sh
+++ b/scripts/validate-graphql-schema.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env sh
+
+# Check for changes in GraphQL schema files
+SCHEMA_CHANGES=$(git diff --cached --name-only -- '*.graphql' '*.gql')
+
+if [ -n "$SCHEMA_CHANGES" ]; then
+  echo "GraphQL schema changes detected. Checking if generated code is up-to-date..."
+
+  # Stash any unstaged changes to avoid interference
+  git stash push --keep-index --quiet
+
+  # Run the codegen tool to see if the generated code would change
+  npx graphql-codegen --check
+
+  # Capture the output of the dry-run
+  CODE_GEN_OUTPUT=$(npx graphql-codegen --check 2>&1)
+
+  # Unstash the changes
+  git stash pop --quiet
+
+  # Check if the dry-run output indicates changes
+  if echo "$CODE_GEN_OUTPUT" | grep -q "Changes detected"; then
+    echo "Error: Generated code is out of sync with the schema."
+    echo "Please run 'npx graphql-codegen' and commit the changes."
+    exit 1
+  else
+    echo "Generated code is up-to-date. Proceeding with the commit."
+  fi
+fi

--- a/scripts/validate-graphql-schema.sh
+++ b/scripts/validate-graphql-schema.sh
@@ -1,29 +1,12 @@
 #!/usr/bin/env sh
 
-# Check for changes in GraphQL schema files
-SCHEMA_CHANGES=$(git diff --cached --name-only -- '*.graphql' '*.gql')
+# Run graphql-codegen and capture its exit status
+npx graphql-codegen --check
+CODEGEN_STATUS=$?
 
-if [ -n "$SCHEMA_CHANGES" ]; then
-  echo "GraphQL schema changes detected. Checking if generated code is up-to-date..."
-
-  # Stash any unstaged changes to avoid interference
-  git stash push --keep-index --quiet
-
-  # Run the codegen tool to see if the generated code would change
-  npx graphql-codegen --check
-
-  # Capture the output of the dry-run
-  CODE_GEN_OUTPUT=$(npx graphql-codegen --check 2>&1)
-
-  # Unstash the changes
-  git stash pop --quiet
-
-  # Check if the dry-run output indicates changes
-  if echo "$CODE_GEN_OUTPUT" | grep -q "Changes detected"; then
-    echo "Error: Generated code is out of sync with the schema."
-    echo "Please run 'npx graphql-codegen' and commit the changes."
-    exit 1
-  else
-    echo "Generated code is up-to-date. Proceeding with the commit."
-  fi
+# Check if the command failed (non-zero exit status)
+if [ $CODEGEN_STATUS -ne 0 ]; then
+  echo "Error: Generated code is out of sync with the schema."
+  echo "Please run 'npx graphql-codegen' and commit the changes."
+  exit 1
 fi


### PR DESCRIPTION
# Implement Pre-commit Hook for GraphQL Schema Validation #1

I added husky to the project to implement the pre-commit hook running 

```sh
npm install --save-dev husky
npx husky init
```

Then I edited the file `.husky/pre-commit` with the solution. The solution has been tested adding a field to the `User` type in the GraphQL schema, the pre-commit hook successfully blocked the commit and showed the error message.

## Summary by Sourcery

Adds a pre-commit hook using Husky to validate the GraphQL schema, preventing commits with schema errors.

Build:
- Adds husky as a dev dependency.
- Configures a pre-commit hook to validate the GraphQL schema.