### PR TITLE
feat(schema): Define AgendaData, Session, Speaker, Category, CategoryItem, and Room types

### DIFF
--- a/generated/react/hooks.ts
+++ b/generated/react/hooks.ts
@@ -92,9 +92,15 @@ export type Session = {
   room: Room;
   speakers: Array<Speaker>;
   startsAt: Scalars['String']['output'];
-  status: Scalars['String']['output'];
+  status: SessionStatus;
   title: Scalars['String']['output'];
 };
+
+export enum SessionStatus {
+  Cancelled = 'CANCELLED',
+  Draft = 'DRAFT',
+  Published = 'PUBLISHED'
+}
 
 export type Speaker = {
   __typename?: 'Speaker';

--- a/generated/react/hooks.ts
+++ b/generated/react/hooks.ts
@@ -15,6 +15,25 @@ export type Scalars = {
   Float: { input: number; output: number; }
 };
 
+export type AgendaData = {
+  __typename?: 'AgendaData';
+  sessions: Array<Session>;
+};
+
+export type Category = {
+  __typename?: 'Category';
+  categoryItems: Array<CategoryItem>;
+  id: Scalars['ID']['output'];
+  name: Scalars['String']['output'];
+  sort: Scalars['Int']['output'];
+};
+
+export type CategoryItem = {
+  __typename?: 'CategoryItem';
+  id: Scalars['ID']['output'];
+  name: Scalars['String']['output'];
+};
+
 export type Mutation = {
   __typename?: 'Mutation';
   viewProfile?: Maybe<User>;
@@ -50,6 +69,37 @@ export type QueryGetProfileAccessesArgs = {
 
 export type QueryGetUserByShortIdArgs = {
   shortId: Scalars['String']['input'];
+};
+
+export type Room = {
+  __typename?: 'Room';
+  id: Scalars['ID']['output'];
+  name: Scalars['String']['output'];
+};
+
+export type Session = {
+  __typename?: 'Session';
+  categories: Array<Category>;
+  description: Scalars['String']['output'];
+  endsAt: Scalars['String']['output'];
+  id: Scalars['ID']['output'];
+  isConfirmed: Scalars['Boolean']['output'];
+  isInformed: Scalars['Boolean']['output'];
+  isPlenumSession: Scalars['Boolean']['output'];
+  isServiceSession: Scalars['Boolean']['output'];
+  liveUrl?: Maybe<Scalars['String']['output']>;
+  recordingUrl?: Maybe<Scalars['String']['output']>;
+  room: Room;
+  speakers: Array<Speaker>;
+  startsAt: Scalars['String']['output'];
+  status: Scalars['String']['output'];
+  title: Scalars['String']['output'];
+};
+
+export type Speaker = {
+  __typename?: 'Speaker';
+  id: Scalars['ID']['output'];
+  name: Scalars['String']['output'];
 };
 
 export type User = {

--- a/generated/ts/types.ts
+++ b/generated/ts/types.ts
@@ -93,9 +93,15 @@ export type Session = {
   room: Room;
   speakers: Array<Speaker>;
   startsAt: Scalars['String']['output'];
-  status: Scalars['String']['output'];
+  status: SessionStatus;
   title: Scalars['String']['output'];
 };
+
+export enum SessionStatus {
+  Cancelled = 'CANCELLED',
+  Draft = 'DRAFT',
+  Published = 'PUBLISHED'
+}
 
 export type Speaker = {
   __typename?: 'Speaker';
@@ -196,6 +202,7 @@ export type ResolversTypes = {
   Query: ResolverTypeWrapper<{}>;
   Room: ResolverTypeWrapper<Room>;
   Session: ResolverTypeWrapper<Session>;
+  SessionStatus: SessionStatus;
   Speaker: ResolverTypeWrapper<Speaker>;
   String: ResolverTypeWrapper<Scalars['String']['output']>;
   User: ResolverTypeWrapper<User>;
@@ -276,7 +283,7 @@ export type SessionResolvers<ContextType = any, ParentType extends ResolversPare
   room?: Resolver<ResolversTypes['Room'], ParentType, ContextType>;
   speakers?: Resolver<Array<ResolversTypes['Speaker']>, ParentType, ContextType>;
   startsAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  status?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  status?: Resolver<ResolversTypes['SessionStatus'], ParentType, ContextType>;
   title?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };

--- a/generated/ts/types.ts
+++ b/generated/ts/types.ts
@@ -16,6 +16,25 @@ export type Scalars = {
   Float: { input: number; output: number; }
 };
 
+export type AgendaData = {
+  __typename?: 'AgendaData';
+  sessions: Array<Session>;
+};
+
+export type Category = {
+  __typename?: 'Category';
+  categoryItems: Array<CategoryItem>;
+  id: Scalars['ID']['output'];
+  name: Scalars['String']['output'];
+  sort: Scalars['Int']['output'];
+};
+
+export type CategoryItem = {
+  __typename?: 'CategoryItem';
+  id: Scalars['ID']['output'];
+  name: Scalars['String']['output'];
+};
+
 export type Mutation = {
   __typename?: 'Mutation';
   viewProfile?: Maybe<User>;
@@ -51,6 +70,37 @@ export type QueryGetProfileAccessesArgs = {
 
 export type QueryGetUserByShortIdArgs = {
   shortId: Scalars['String']['input'];
+};
+
+export type Room = {
+  __typename?: 'Room';
+  id: Scalars['ID']['output'];
+  name: Scalars['String']['output'];
+};
+
+export type Session = {
+  __typename?: 'Session';
+  categories: Array<Category>;
+  description: Scalars['String']['output'];
+  endsAt: Scalars['String']['output'];
+  id: Scalars['ID']['output'];
+  isConfirmed: Scalars['Boolean']['output'];
+  isInformed: Scalars['Boolean']['output'];
+  isPlenumSession: Scalars['Boolean']['output'];
+  isServiceSession: Scalars['Boolean']['output'];
+  liveUrl?: Maybe<Scalars['String']['output']>;
+  recordingUrl?: Maybe<Scalars['String']['output']>;
+  room: Room;
+  speakers: Array<Speaker>;
+  startsAt: Scalars['String']['output'];
+  status: Scalars['String']['output'];
+  title: Scalars['String']['output'];
+};
+
+export type Speaker = {
+  __typename?: 'Speaker';
+  id: Scalars['ID']['output'];
+  name: Scalars['String']['output'];
 };
 
 export type User = {
@@ -135,26 +185,57 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
 
 /** Mapping between all available schema types and the resolvers types */
 export type ResolversTypes = {
+  AgendaData: ResolverTypeWrapper<AgendaData>;
   Boolean: ResolverTypeWrapper<Scalars['Boolean']['output']>;
+  Category: ResolverTypeWrapper<Category>;
+  CategoryItem: ResolverTypeWrapper<CategoryItem>;
   ID: ResolverTypeWrapper<Scalars['ID']['output']>;
   Int: ResolverTypeWrapper<Scalars['Int']['output']>;
   Mutation: ResolverTypeWrapper<{}>;
   ProfileAccess: ResolverTypeWrapper<ProfileAccess>;
   Query: ResolverTypeWrapper<{}>;
+  Room: ResolverTypeWrapper<Room>;
+  Session: ResolverTypeWrapper<Session>;
+  Speaker: ResolverTypeWrapper<Speaker>;
   String: ResolverTypeWrapper<Scalars['String']['output']>;
   User: ResolverTypeWrapper<User>;
 };
 
 /** Mapping between all available schema types and the resolvers parents */
 export type ResolversParentTypes = {
+  AgendaData: AgendaData;
   Boolean: Scalars['Boolean']['output'];
+  Category: Category;
+  CategoryItem: CategoryItem;
   ID: Scalars['ID']['output'];
   Int: Scalars['Int']['output'];
   Mutation: {};
   ProfileAccess: ProfileAccess;
   Query: {};
+  Room: Room;
+  Session: Session;
+  Speaker: Speaker;
   String: Scalars['String']['output'];
   User: User;
+};
+
+export type AgendaDataResolvers<ContextType = any, ParentType extends ResolversParentTypes['AgendaData'] = ResolversParentTypes['AgendaData']> = {
+  sessions?: Resolver<Array<ResolversTypes['Session']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type CategoryResolvers<ContextType = any, ParentType extends ResolversParentTypes['Category'] = ResolversParentTypes['Category']> = {
+  categoryItems?: Resolver<Array<ResolversTypes['CategoryItem']>, ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  sort?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type CategoryItemResolvers<ContextType = any, ParentType extends ResolversParentTypes['CategoryItem'] = ResolversParentTypes['CategoryItem']> = {
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
 export type MutationResolvers<ContextType = any, ParentType extends ResolversParentTypes['Mutation'] = ResolversParentTypes['Mutation']> = {
@@ -175,6 +256,37 @@ export type QueryResolvers<ContextType = any, ParentType extends ResolversParent
   getUserByShortId?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType, RequireFields<QueryGetUserByShortIdArgs, 'shortId'>>;
 };
 
+export type RoomResolvers<ContextType = any, ParentType extends ResolversParentTypes['Room'] = ResolversParentTypes['Room']> = {
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type SessionResolvers<ContextType = any, ParentType extends ResolversParentTypes['Session'] = ResolversParentTypes['Session']> = {
+  categories?: Resolver<Array<ResolversTypes['Category']>, ParentType, ContextType>;
+  description?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  endsAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  isConfirmed?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  isInformed?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  isPlenumSession?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  isServiceSession?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  liveUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  recordingUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  room?: Resolver<ResolversTypes['Room'], ParentType, ContextType>;
+  speakers?: Resolver<Array<ResolversTypes['Speaker']>, ParentType, ContextType>;
+  startsAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  status?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  title?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type SpeakerResolvers<ContextType = any, ParentType extends ResolversParentTypes['Speaker'] = ResolversParentTypes['Speaker']> = {
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
 export type UserResolvers<ContextType = any, ParentType extends ResolversParentTypes['User'] = ResolversParentTypes['User']> = {
   company?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   first_name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
@@ -187,9 +299,15 @@ export type UserResolvers<ContextType = any, ParentType extends ResolversParentT
 };
 
 export type Resolvers<ContextType = any> = {
+  AgendaData?: AgendaDataResolvers<ContextType>;
+  Category?: CategoryResolvers<ContextType>;
+  CategoryItem?: CategoryItemResolvers<ContextType>;
   Mutation?: MutationResolvers<ContextType>;
   ProfileAccess?: ProfileAccessResolvers<ContextType>;
   Query?: QueryResolvers<ContextType>;
+  Room?: RoomResolvers<ContextType>;
+  Session?: SessionResolvers<ContextType>;
+  Speaker?: SpeakerResolvers<ContextType>;
   User?: UserResolvers<ContextType>;
 };
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -29,3 +29,47 @@ schema {
   query: Query
   mutation: Mutation
 }
+
+type  AgendaData {
+  sessions: [Session!]!
+}
+
+type  Session {
+  id: ID!
+  title: String!
+  description: String!
+  startsAt: String!
+  endsAt: String!
+  isServiceSession: Boolean!
+  isPlenumSession: Boolean!
+  speakers: [Speaker!]!
+  categories: [Category!]!
+  room: Room!
+  liveUrl: String
+  recordingUrl: String
+  status: String!
+  isInformed: Boolean!
+  isConfirmed: Boolean!
+}
+
+type  Speaker {
+  id: ID!
+  name: String!
+}
+
+type  Category {
+  id: ID!
+  name: String!
+  categoryItems: [CategoryItem!]!
+  sort: Int!
+}
+
+type  CategoryItem {
+  id: ID!
+  name: String!
+}
+
+type Room {
+  id: ID!
+  name: String!
+}

--- a/schema.graphql
+++ b/schema.graphql
@@ -47,7 +47,7 @@ type  Session {
   room: Room!
   liveUrl: String
   recordingUrl: String
-  status: String!
+  status: SessionStatus!
   isInformed: Boolean!
   isConfirmed: Boolean!
 }
@@ -72,4 +72,10 @@ type  CategoryItem {
 type Room {
   id: ID!
   name: String!
+}
+
+enum SessionStatus {
+  DRAFT
+  PUBLISHED
+  CANCELLED
 }


### PR DESCRIPTION
# Pull Request

## Summary

<!-- Provide a brief summary of your changes -->

## Related Issues
Closes #50 
<!-- Link to any related issues or tickets (e.g., Fixes #123) -->

## Test Plan

<!-- How did you test these changes? What tests did you add/update? -->
![image](https://github.com/user-attachments/assets/cb132b47-ce10-4640-ac75-daf6c2a25a53)


## Types of Changes

<!-- What types of changes does your code introduce? Put an 'x' in all boxes that apply -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation changes
- [ ] Performance improvements
- [ ] Refactoring
- [ ] Test updates

## Checklist

<!-- Go over all the following points, and put an 'x' in all boxes that apply -->

- [ ] My code follows the style guidelines of this project
- [ ] I have added tests that cover my changes
- [ ] All new and existing tests passed
- [ ] My changes generate no new warnings
- [ ] I have updated the documentation accordingly
- [ ] I have added a changelog entry if necessary
- [ ] The PR title follows the conventional commit format: `type(scope): description`

## Summary by Sourcery

Define GraphQL schema types for conference session management, including AgendaData, Session, Speaker, Category, CategoryItem, and Room

New Features:
- Create comprehensive GraphQL type definitions for conference session-related entities, enabling detailed representation of conference agenda and session information

Enhancements:
- Expand the GraphQL schema to support rich metadata about conference sessions, including session details, speakers, categories, and room information