### PR TITLE
Fix/#78 use barcode id for qr

### DIFF
--- a/lambda/twilio-message-sender/requirements.txt
+++ b/lambda/twilio-message-sender/requirements.txt
@@ -1,5 +1,5 @@
 twilio==8.5.0
 boto3==1.26.137
-Pillow==10.0.0
-requests==2.31.0
+Pillow==11.2.1
+requests==2.32.3
 qrcode[pil]==7.4.2

--- a/lib/backend-stack.ts
+++ b/lib/backend-stack.ts
@@ -63,7 +63,7 @@ export class BackendStack extends cdk.Stack {
       authDomain: props.authDomain,
       certificate: domainCert,
       hostedZone: hostedZone,
-      groups: ['Attendees', 'Sponsors'],
+      groups: ['Attendees', 'Sponsors', 'CheckInVolunteers'],
     });
 
     const apiStack = new ApiStack(this, 'ApiStack', {

--- a/lib/stacks/database.ts
+++ b/lib/stacks/database.ts
@@ -45,6 +45,15 @@ export class DatabaseStack extends Construct {
       projectionType: dynamodb.ProjectionType.ALL,
     });
 
+    this.table.addGlobalSecondaryIndex({
+      indexName: 'barcode-index',
+      partitionKey: {
+        name: 'barcode',
+        type: dynamodb.AttributeType.STRING,
+      },
+      projectionType: dynamodb.ProjectionType.ALL,
+    });
+
     // Export the table name
     new cdk.CfnOutput(this, 'TableName', {
       value: this.table.tableName,

--- a/lib/stacks/user-step-function.ts
+++ b/lib/stacks/user-step-function.ts
@@ -178,7 +178,7 @@ export class UserStepFunctionStack extends Construct {
         nombre_usuario: JsonPath.stringAt('$.body.profile.first_name'),
         email_usuario: JsonPath.stringAt('$.body.profile.email'),
         telefono: JsonPath.stringAt('$.processedPhoneNumber.processedPhoneNumber.clean_phone'),
-        texto_qr: JsonPath.stringAt('$.body.order_id'),
+        texto_qr: JsonPath.stringAt('$.body.barcodes[0].barcode'),
         nombre_completo: JsonPath.stringAt('$.body.profile.name'),
       }),
     });


### PR DESCRIPTION
# Pull Request

## Summary

<!-- Provide a brief summary of your changes -->

## Related Issues

<!-- Link to any related issues or tickets (e.g., Fixes #123) -->

## Test Plan

<!-- How did you test these changes? What tests did you add/update? -->

## Screenshots/Videos

<!-- If applicable, add screenshots or videos to help explain your changes -->

## Types of Changes

<!-- What types of changes does your code introduce? Put an 'x' in all boxes that apply -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation changes
- [ ] Performance improvements
- [ ] Refactoring
- [ ] Test updates

## Checklist

<!-- Go over all the following points, and put an 'x' in all boxes that apply -->

- [ ] My code follows the style guidelines of this project
- [ ] I have added tests that cover my changes
- [ ] All new and existing tests passed
- [ ] My changes generate no new warnings
- [ ] I have updated the documentation accordingly
- [ ] I have added a changelog entry if necessary
- [ ] The PR title follows the conventional commit format: `type(scope): description`

## Summary by Sourcery

Use barcode ID for QR code generation and data storage by updating the user step function, adding a DynamoDB secondary index, and including a new Cognito group; also bump image and HTTP libraries

Enhancements:
- Use barcode field instead of order ID for QR code text
- Persist barcode to the user’s DynamoDB profile when provided
- Add a global secondary index on the barcode attribute to the DynamoDB table
- Add 'CheckInVolunteers' to the Cognito user groups

Build:
- Upgrade Pillow to 11.2.1 and requests to 2.32.3 in the Twilio message sender lambda