### PR TITLE
Update GraphQL schema to add updateAgenda mutation and subscription

### DIFF
--- a/generated/react/hooks.ts
+++ b/generated/react/hooks.ts
@@ -20,6 +20,10 @@ export type AgendaData = {
   sessions: Array<Session>;
 };
 
+export type AgendaDataInput = {
+  sessions: Array<SessionInput>;
+};
+
 export type Category = {
   __typename?: 'Category';
   categoryItems: Array<CategoryItem>;
@@ -28,10 +32,22 @@ export type Category = {
   sort: Scalars['Int']['output'];
 };
 
+export type CategoryInput = {
+  categoryItems: Array<CategoryItemInput>;
+  id: Scalars['ID']['input'];
+  name: Scalars['String']['input'];
+  sort: Scalars['Int']['input'];
+};
+
 export type CategoryItem = {
   __typename?: 'CategoryItem';
   id: Scalars['ID']['output'];
   name: Scalars['String']['output'];
+};
+
+export type CategoryItemInput = {
+  id: Scalars['ID']['input'];
+  name: Scalars['String']['input'];
 };
 
 export type CheckInResponse = {
@@ -51,6 +67,8 @@ export type Mutation = {
   __typename?: 'Mutation';
   checkInAttendee: CheckInResponse;
   registerSponsorVisit?: Maybe<SponsorUser>;
+  updateAgenda?: Maybe<AgendaData>;
+  updateRoomAgenda?: Maybe<RoomAgendaData>;
   updateUser?: Maybe<User>;
   viewProfile?: Maybe<User>;
 };
@@ -68,6 +86,17 @@ export type MutationCheckInAttendeeArgs = {
 
 export type MutationRegisterSponsorVisitArgs = {
   input: RegisterSponsorVisitInput;
+};
+
+
+export type MutationUpdateAgendaArgs = {
+  sessions: AgendaDataInput;
+};
+
+
+export type MutationUpdateRoomAgendaArgs = {
+  location: Scalars['String']['input'];
+  sessions: AgendaDataInput;
 };
 
 
@@ -111,6 +140,17 @@ export type Room = {
   name: Scalars['String']['output'];
 };
 
+export type RoomAgendaData = {
+  __typename?: 'RoomAgendaData';
+  location: Scalars['String']['output'];
+  sessions: Array<Session>;
+};
+
+export type RoomInput = {
+  id: Scalars['ID']['input'];
+  name: Scalars['String']['input'];
+};
+
 export type Session = {
   __typename?: 'Session';
   categories: Array<Category>;
@@ -130,6 +170,24 @@ export type Session = {
   title: Scalars['String']['output'];
 };
 
+export type SessionInput = {
+  categories: Array<CategoryInput>;
+  description: Scalars['String']['input'];
+  endsAt: Scalars['String']['input'];
+  id: Scalars['ID']['input'];
+  isConfirmed: Scalars['Boolean']['input'];
+  isInformed: Scalars['Boolean']['input'];
+  isPlenumSession: Scalars['Boolean']['input'];
+  isServiceSession: Scalars['Boolean']['input'];
+  liveUrl?: InputMaybe<Scalars['String']['input']>;
+  recordingUrl?: InputMaybe<Scalars['String']['input']>;
+  room: RoomInput;
+  speakers: Array<SpeakerInput>;
+  startsAt: Scalars['String']['input'];
+  status: SessionStatus;
+  title: Scalars['String']['input'];
+};
+
 export enum SessionStatus {
   Cancelled = 'CANCELLED',
   Draft = 'DRAFT',
@@ -140,6 +198,11 @@ export type Speaker = {
   __typename?: 'Speaker';
   id: Scalars['ID']['output'];
   name: Scalars['String']['output'];
+};
+
+export type SpeakerInput = {
+  id: Scalars['ID']['input'];
+  name: Scalars['String']['input'];
 };
 
 export type SponsorDashboard = {
@@ -160,6 +223,17 @@ export type SponsorUser = {
   name: Scalars['String']['output'];
   short_id?: Maybe<Scalars['String']['output']>;
   user_id: Scalars['ID']['output'];
+};
+
+export type Subscription = {
+  __typename?: 'Subscription';
+  onAgendaUpdate?: Maybe<AgendaData>;
+  onRoomAgendaUpdate?: Maybe<RoomAgendaData>;
+};
+
+
+export type SubscriptionOnRoomAgendaUpdateArgs = {
+  location: Scalars['String']['input'];
 };
 
 export type UpdateUserInput = {

--- a/generated/ts/graphql-types.ts
+++ b/generated/ts/graphql-types.ts
@@ -21,6 +21,10 @@ export type AgendaData = {
   sessions: Array<Session>;
 };
 
+export type AgendaDataInput = {
+  sessions: Array<SessionInput>;
+};
+
 export type Category = {
   __typename?: 'Category';
   categoryItems: Array<CategoryItem>;
@@ -29,10 +33,22 @@ export type Category = {
   sort: Scalars['Int']['output'];
 };
 
+export type CategoryInput = {
+  categoryItems: Array<CategoryItemInput>;
+  id: Scalars['ID']['input'];
+  name: Scalars['String']['input'];
+  sort: Scalars['Int']['input'];
+};
+
 export type CategoryItem = {
   __typename?: 'CategoryItem';
   id: Scalars['ID']['output'];
   name: Scalars['String']['output'];
+};
+
+export type CategoryItemInput = {
+  id: Scalars['ID']['input'];
+  name: Scalars['String']['input'];
 };
 
 export type CheckInResponse = {
@@ -52,6 +68,8 @@ export type Mutation = {
   __typename?: 'Mutation';
   checkInAttendee: CheckInResponse;
   registerSponsorVisit?: Maybe<SponsorUser>;
+  updateAgenda?: Maybe<AgendaData>;
+  updateRoomAgenda?: Maybe<RoomAgendaData>;
   updateUser?: Maybe<User>;
   viewProfile?: Maybe<User>;
 };
@@ -69,6 +87,17 @@ export type MutationCheckInAttendeeArgs = {
 
 export type MutationRegisterSponsorVisitArgs = {
   input: RegisterSponsorVisitInput;
+};
+
+
+export type MutationUpdateAgendaArgs = {
+  sessions: AgendaDataInput;
+};
+
+
+export type MutationUpdateRoomAgendaArgs = {
+  location: Scalars['String']['input'];
+  sessions: AgendaDataInput;
 };
 
 
@@ -112,6 +141,17 @@ export type Room = {
   name: Scalars['String']['output'];
 };
 
+export type RoomAgendaData = {
+  __typename?: 'RoomAgendaData';
+  location: Scalars['String']['output'];
+  sessions: Array<Session>;
+};
+
+export type RoomInput = {
+  id: Scalars['ID']['input'];
+  name: Scalars['String']['input'];
+};
+
 export type Session = {
   __typename?: 'Session';
   categories: Array<Category>;
@@ -131,6 +171,24 @@ export type Session = {
   title: Scalars['String']['output'];
 };
 
+export type SessionInput = {
+  categories: Array<CategoryInput>;
+  description: Scalars['String']['input'];
+  endsAt: Scalars['String']['input'];
+  id: Scalars['ID']['input'];
+  isConfirmed: Scalars['Boolean']['input'];
+  isInformed: Scalars['Boolean']['input'];
+  isPlenumSession: Scalars['Boolean']['input'];
+  isServiceSession: Scalars['Boolean']['input'];
+  liveUrl?: InputMaybe<Scalars['String']['input']>;
+  recordingUrl?: InputMaybe<Scalars['String']['input']>;
+  room: RoomInput;
+  speakers: Array<SpeakerInput>;
+  startsAt: Scalars['String']['input'];
+  status: SessionStatus;
+  title: Scalars['String']['input'];
+};
+
 export enum SessionStatus {
   Cancelled = 'CANCELLED',
   Draft = 'DRAFT',
@@ -141,6 +199,11 @@ export type Speaker = {
   __typename?: 'Speaker';
   id: Scalars['ID']['output'];
   name: Scalars['String']['output'];
+};
+
+export type SpeakerInput = {
+  id: Scalars['ID']['input'];
+  name: Scalars['String']['input'];
 };
 
 export type SponsorDashboard = {
@@ -161,6 +224,17 @@ export type SponsorUser = {
   name: Scalars['String']['output'];
   short_id?: Maybe<Scalars['String']['output']>;
   user_id: Scalars['ID']['output'];
+};
+
+export type Subscription = {
+  __typename?: 'Subscription';
+  onAgendaUpdate?: Maybe<AgendaData>;
+  onRoomAgendaUpdate?: Maybe<RoomAgendaData>;
+};
+
+
+export type SubscriptionOnRoomAgendaUpdateArgs = {
+  location: Scalars['String']['input'];
 };
 
 export type UpdateUserInput = {
@@ -260,9 +334,12 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
 /** Mapping between all available schema types and the resolvers types */
 export type ResolversTypes = {
   AgendaData: ResolverTypeWrapper<AgendaData>;
+  AgendaDataInput: AgendaDataInput;
   Boolean: ResolverTypeWrapper<Scalars['Boolean']['output']>;
   Category: ResolverTypeWrapper<Category>;
+  CategoryInput: CategoryInput;
   CategoryItem: ResolverTypeWrapper<CategoryItem>;
+  CategoryItemInput: CategoryItemInput;
   CheckInResponse: ResolverTypeWrapper<CheckInResponse>;
   CheckInStatus: CheckInStatus;
   ID: ResolverTypeWrapper<Scalars['ID']['output']>;
@@ -272,12 +349,17 @@ export type ResolversTypes = {
   Query: ResolverTypeWrapper<{}>;
   RegisterSponsorVisitInput: RegisterSponsorVisitInput;
   Room: ResolverTypeWrapper<Room>;
+  RoomAgendaData: ResolverTypeWrapper<RoomAgendaData>;
+  RoomInput: RoomInput;
   Session: ResolverTypeWrapper<Session>;
+  SessionInput: SessionInput;
   SessionStatus: SessionStatus;
   Speaker: ResolverTypeWrapper<Speaker>;
+  SpeakerInput: SpeakerInput;
   SponsorDashboard: ResolverTypeWrapper<SponsorDashboard>;
   SponsorUser: ResolverTypeWrapper<SponsorUser>;
   String: ResolverTypeWrapper<Scalars['String']['output']>;
+  Subscription: ResolverTypeWrapper<{}>;
   UpdateUserInput: UpdateUserInput;
   User: ResolverTypeWrapper<User>;
 };
@@ -285,9 +367,12 @@ export type ResolversTypes = {
 /** Mapping between all available schema types and the resolvers parents */
 export type ResolversParentTypes = {
   AgendaData: AgendaData;
+  AgendaDataInput: AgendaDataInput;
   Boolean: Scalars['Boolean']['output'];
   Category: Category;
+  CategoryInput: CategoryInput;
   CategoryItem: CategoryItem;
+  CategoryItemInput: CategoryItemInput;
   CheckInResponse: CheckInResponse;
   ID: Scalars['ID']['output'];
   Int: Scalars['Int']['output'];
@@ -296,11 +381,16 @@ export type ResolversParentTypes = {
   Query: {};
   RegisterSponsorVisitInput: RegisterSponsorVisitInput;
   Room: Room;
+  RoomAgendaData: RoomAgendaData;
+  RoomInput: RoomInput;
   Session: Session;
+  SessionInput: SessionInput;
   Speaker: Speaker;
+  SpeakerInput: SpeakerInput;
   SponsorDashboard: SponsorDashboard;
   SponsorUser: SponsorUser;
   String: Scalars['String']['output'];
+  Subscription: {};
   UpdateUserInput: UpdateUserInput;
   User: User;
 };
@@ -335,6 +425,8 @@ export type CheckInResponseResolvers<ContextType = any, ParentType extends Resol
 export type MutationResolvers<ContextType = any, ParentType extends ResolversParentTypes['Mutation'] = ResolversParentTypes['Mutation']> = {
   checkInAttendee?: Resolver<ResolversTypes['CheckInResponse'], ParentType, ContextType, Partial<MutationCheckInAttendeeArgs>>;
   registerSponsorVisit?: Resolver<Maybe<ResolversTypes['SponsorUser']>, ParentType, ContextType, RequireFields<MutationRegisterSponsorVisitArgs, 'input'>>;
+  updateAgenda?: Resolver<Maybe<ResolversTypes['AgendaData']>, ParentType, ContextType, RequireFields<MutationUpdateAgendaArgs, 'sessions'>>;
+  updateRoomAgenda?: Resolver<Maybe<ResolversTypes['RoomAgendaData']>, ParentType, ContextType, RequireFields<MutationUpdateRoomAgendaArgs, 'location' | 'sessions'>>;
   updateUser?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType, RequireFields<MutationUpdateUserArgs, 'input'>>;
   viewProfile?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType, RequireFields<MutationViewProfileArgs, 'id' | 'pin'>>;
 };
@@ -355,6 +447,12 @@ export type QueryResolvers<ContextType = any, ParentType extends ResolversParent
 export type RoomResolvers<ContextType = any, ParentType extends ResolversParentTypes['Room'] = ResolversParentTypes['Room']> = {
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type RoomAgendaDataResolvers<ContextType = any, ParentType extends ResolversParentTypes['RoomAgendaData'] = ResolversParentTypes['RoomAgendaData']> = {
+  location?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  sessions?: Resolver<Array<ResolversTypes['Session']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -403,6 +501,11 @@ export type SponsorUserResolvers<ContextType = any, ParentType extends Resolvers
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
+export type SubscriptionResolvers<ContextType = any, ParentType extends ResolversParentTypes['Subscription'] = ResolversParentTypes['Subscription']> = {
+  onAgendaUpdate?: SubscriptionResolver<Maybe<ResolversTypes['AgendaData']>, "onAgendaUpdate", ParentType, ContextType>;
+  onRoomAgendaUpdate?: SubscriptionResolver<Maybe<ResolversTypes['RoomAgendaData']>, "onRoomAgendaUpdate", ParentType, ContextType, RequireFields<SubscriptionOnRoomAgendaUpdateArgs, 'location'>>;
+};
+
 export type UserResolvers<ContextType = any, ParentType extends ResolversParentTypes['User'] = ResolversParentTypes['User']> = {
   cell_phone?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   company?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
@@ -429,10 +532,12 @@ export type Resolvers<ContextType = any> = {
   ProfileAccess?: ProfileAccessResolvers<ContextType>;
   Query?: QueryResolvers<ContextType>;
   Room?: RoomResolvers<ContextType>;
+  RoomAgendaData?: RoomAgendaDataResolvers<ContextType>;
   Session?: SessionResolvers<ContextType>;
   Speaker?: SpeakerResolvers<ContextType>;
   SponsorDashboard?: SponsorDashboardResolvers<ContextType>;
   SponsorUser?: SponsorUserResolvers<ContextType>;
+  Subscription?: SubscriptionResolvers<ContextType>;
   User?: UserResolvers<ContextType>;
 };
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -72,6 +72,13 @@ enum CheckInStatus {
   INCOMPLETE_PROFILE
 }
 
+type Subscription {
+  onAgendaUpdate: AgendaData
+    @aws_subscribe(mutations: ["updateAgenda"])
+  onRoomAgendaUpdate(location: String!): RoomAgendaData 
+    @aws_subscribe(mutations: ["updateRoomAgenda"])
+}
+
 type Mutation {
   viewProfile(id: String!, pin: String!): User
   @aws_auth(cognito_groups: ["Attendees"])
@@ -88,11 +95,16 @@ type Mutation {
     phone: String
   ): CheckInResponse!
   @aws_auth(cognito_groups: ["CheckInVolunteerMain1", "CheckInVolunteerMain2", "CheckInVolunteerMain3", "CheckInVolunteerMain4", "CheckInVolunteerSecondary"])
+  updateAgenda(sessions: AgendaDataInput!): AgendaData 
+    @aws_api_key
+  updateRoomAgenda(location: String!, sessions: AgendaDataInput!): RoomAgendaData 
+    @aws_api_key
 }
 
 schema {
   query: Query
   mutation: Mutation
+  subscription: Subscription
 }
 
 type AgendaData {
@@ -143,4 +155,53 @@ enum SessionStatus {
   DRAFT
   PUBLISHED
   CANCELLED
+}
+
+type RoomAgendaData {
+  location: String!
+  sessions: [Session!]!
+}
+
+input AgendaDataInput {
+  sessions: [SessionInput!]!
+}
+
+input SessionInput {
+  id: ID!
+  title: String!
+  description: String!
+  startsAt: String!
+  endsAt: String!
+  isServiceSession: Boolean!
+  isPlenumSession: Boolean!
+  speakers: [SpeakerInput!]!
+  categories: [CategoryInput!]!
+  room: RoomInput!
+  liveUrl: String
+  recordingUrl: String
+  status: SessionStatus!
+  isInformed: Boolean!
+  isConfirmed: Boolean!
+}
+
+input SpeakerInput {
+  id: ID!
+  name: String!
+}
+
+input CategoryInput {
+  id: ID!
+  name: String!
+  categoryItems: [CategoryItemInput!]!
+  sort: Int!
+}
+
+input CategoryItemInput {
+  id: ID!
+  name: String!
+}
+
+input RoomInput {
+  id: ID!
+  name: String!
 }


### PR DESCRIPTION
# Pull Request

## Summary

<!-- Provide a brief summary of your changes -->

## Related Issues

<!-- Link to any related issues or tickets (e.g., Fixes #123) -->

## Test Plan

<!-- How did you test these changes? What tests did you add/update? -->

## Screenshots/Videos

<!-- If applicable, add screenshots or videos to help explain your changes -->

## Types of Changes

<!-- What types of changes does your code introduce? Put an 'x' in all boxes that apply -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation changes
- [ ] Performance improvements
- [ ] Refactoring
- [ ] Test updates

## Checklist

<!-- Go over all the following points, and put an 'x' in all boxes that apply -->

- [ ] My code follows the style guidelines of this project
- [ ] I have added tests that cover my changes
- [ ] All new and existing tests passed
- [ ] My changes generate no new warnings
- [ ] I have updated the documentation accordingly
- [ ] I have added a changelog entry if necessary
- [ ] The PR title follows the conventional commit format: `type(scope): description`

## Summary by Sourcery

Add GraphQL support for updating agendas by defining new mutations, subscriptions, and related input and output types, and regenerate client code accordingly

New Features:
- Add updateAgenda and updateRoomAgenda mutations with API key authorization
- Add onAgendaUpdate and onRoomAgendaUpdate subscriptions for real-time agenda changes

Enhancements:
- Introduce input types and output types (AgendaDataInput, SessionInput, SpeakerInput, CategoryInput, CategoryItemInput, RoomInput, RoomAgendaData) to model agenda updates
- Regenerate React hooks and TypeScript types to reflect schema changes